### PR TITLE
Implemented key to use the bech32 content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,6 +1923,7 @@ name = "proxy"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bech32",
  "dotenv",
  "futures-util",
  "leaky-bucket",

--- a/operator/src/utils.rs
+++ b/operator/src/utils.rs
@@ -23,6 +23,7 @@ pub async fn patch_resource_status(
     let patch_params = PatchParams::default();
     api.patch_status(name, &patch_params, &Patch::Merge(status))
         .await?;
+
     Ok(())
 }
 
@@ -38,8 +39,6 @@ pub async fn build_api_key(crd: &CardanoNodePort) -> Result<String, Error> {
     let namespace = crd.namespace().unwrap();
     let name = format!("cardano-node-auth-{}", &crd.name_any());
 
-    let network = &crd.spec.network;
-    let version = &crd.spec.version;
     let password = format!("{}{}", name, namespace).as_bytes().to_vec();
 
     let config = get_config();
@@ -50,7 +49,7 @@ pub async fn build_api_key(crd: &CardanoNodePort) -> Result<String, Error> {
     let argon2 = Argon2::default();
     argon2.hash_password_into(password.as_slice(), salt, &mut output)?;
 
-    let hrp = Hrp::parse(&format!("dmtr_cnode_{version}_{network}_"))?;
+    let hrp = Hrp::parse("cnode")?;
     let with_bech = bech32::encode::<Bech32m>(hrp, output.as_slice())?;
 
     Ok(with_bech)

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 toml = "0.8.10"
 notify = "6.1.1"
+bech32 = "0.11.0"


### PR DESCRIPTION
Close #57 

All of the keys already created will be updated to use the new prefix, but the old one will not stop working because the proxy was changed to validate the content of the bech32.

New key prefix example
`cnode1ph9y0en7j97kj6ze56a`