### PR TITLE
feat(bootstrap): add tolerations support to instances module

### DIFF
--- a/bootstrap/instance/main.tf
+++ b/bootstrap/instance/main.tf
@@ -95,3 +95,14 @@ variable "is_custom" {
 variable "is_relay" {
   default = false
 }
+
+variable "tolerations" {
+  description = "List of tolerations for the node"
+  type = list(object({
+    effect   = string
+    key      = string
+    operator = string
+    value    = string
+  }))
+  default = []
+}

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -84,6 +84,7 @@ module "instances" {
   restore            = coalesce(each.value.restore, false)
   is_custom          = coalesce(each.value.is_custom, false)
   is_relay           = coalesce(each.value.is_relay, false)
+  tolerations        = coalesce(each.value.tolerations, [])
 }
 
 module "custom_configs" {

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -160,6 +160,12 @@ variable "instances" {
     availability_sla   = optional(string)
     is_custom          = optional(bool)
     is_relay           = optional(bool, false)
+    tolerations = optional(list(object({
+      effect   = string
+      key      = string
+      operator = string
+      value    = string
+    })), [])
   }))
 }
 


### PR DESCRIPTION
It allows additional tolerations required for kubernetes.io taints in (GCP) while maintaining backward compatibility with the previously defined default tolerations.